### PR TITLE
Remove EOSIO references for docs launch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ EOSJS is used by many libraries across the EOSIO ecosystem, so proper testing is
 
 #### Integration Test Suite
 
-Integration tests will only work with a local node running on port 8888 and with test accounts "bob" and "alice".  This can be accomplished by following the [EOSIO Developer Getting Started Guide](https://developers.eos.io/eosio-home/docs/getting-the-software#section-step-1-1-start-keosd).
+Integration tests will only work with a local node running on port 8888 and with test accounts "bob" and "alice".  
 
 ##### Web Environment
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # eosjs ![npm](https://img.shields.io/npm/dw/eosjs.svg)
 
-Javascript API for integration with EOSIO-based blockchains using [EOSIO RPC API](https://developers.eos.io/eosio-nodeos/reference).
-
-Documentation can be found [here](https://eosio.github.io/eosjs)
+Javascript API for integration with EOSIO-based blockchains using [EOSIO RPC API](/developer-tools/nodeos/).
 
 ## Installation
 
 ### NPM
 
-The official distribution package can be found at [npm](https://www.npmjs.com/package/eosjs).
+The officially distributed npm packed will be posted soon.
 
 ### NodeJS Dependency
 
@@ -31,7 +29,7 @@ If you're using Node (not a browser) then you'll also need to make sure the `dom
 
 ### Browser Distribution
 
-Clone this repository locally then run `yarn build-web`.  The browser distribution will be located in `dist-web` and can be directly copied into your project repository. The `dist-web` folder contains minified bundles ready for production, along with source mapped versions of the library for debugging.  For full browser usage examples, [see the documentation](https://eosio.github.io/eosjs/guides/1.-Browsers.html).
+Clone this repository locally then run `yarn build-web`.  The browser distribution will be located in `dist-web` and can be directly copied into your project repository. The `dist-web` folder contains minified bundles ready for production, along with source mapped versions of the library for debugging.
 
 ## Import
 
@@ -138,6 +136,6 @@ try {
 
 ## Important
 
-See LICENSE for copyright and license terms.  Block.one makes its contribution on a voluntary basis as a member of the EOSIO community and is not responsible for ensuring the overall performance of the software or any related applications.  We make no representation, warranty, guarantee or undertaking in respect of the software or any related documentation, whether expressed or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. In no event shall we be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the software or documentation or the use or other dealings in the software or documentation. Any test results or performance figures are indicative and will not reflect performance under all conditions.  Any reference to any third party or third-party product, service or other resource is not an endorsement or recommendation by Block.one.  We are not responsible, and disclaim any and all responsibility and liability, for your use of or reliance on any of these resources. Third-party resources may be updated, changed or terminated at any time, so the information here may be out of date or inaccurate.  Any person using or offering this software in connection with providing software, goods or services to third parties shall advise such third parties of these license terms, disclaimers and exclusions of liability.  Block.one, EOSIO, EOSIO Labs, EOS, the heptahedron and associated logos are trademarks of Block.one.
+See LICENSE for copyright and license terms. This work is made on a voluntary basis as a member of the EOSIO community and is not responsible for ensuring the overall performance of the software or any related applications.  We make no representation, warranty, guarantee or undertaking in respect of the software or any related documentation, whether expressed or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. In no event shall we be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the software or documentation or the use or other dealings in the software or documentation. Any test results or performance figures are indicative and will not reflect performance under all conditions.  Any reference to any third party or third-party product, service or other resource is not an endorsement or recommendation by Block.one.  We are not responsible, and disclaim any and all responsibility and liability, for your use of or reliance on any of these resources. Third-party resources may be updated, changed or terminated at any time, so the information here may be out of date or inaccurate.  Any person using or offering this software in connection with providing software, goods or services to third parties shall advise such third parties of these license terms, disclaimers and exclusions of liability.  Block.one, EOSIO, EOSIO Labs, EOS, EOS Network Foundation.
 
 Wallets and related components are complex software that require the highest levels of security.  If incorrectly built or used, they may compromise users’ private keys and digital assets. Wallet applications and related components should undergo thorough security evaluations before being used.  Only experienced developers should work with this software.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eosjs ![npm](https://img.shields.io/npm/dw/eosjs.svg)
 
-Javascript API for integration with EOSIO-based blockchains using [EOSIO RPC API](/developer-tools/nodeos/).
+Javascript API for integration with EOSIO-based blockchains using [EOSIO RPC API](/developer-tools/01_nodeos/index.md).
 
 ## Installation
 

--- a/docs/5.-Testing and Building with DUNE.md
+++ b/docs/5.-Testing and Building with DUNE.md
@@ -1,0 +1,75 @@
+# Testing and Building with DUNE
+
+DUNE makes it easier to test locally. Performing integration tests with DUNE requires some setup.
+[DUNE may be installed from git hub](https://github.com/eosnetworkfoundation/DUNE)
+
+## Open Local Node Port
+
+Need to change **scripts/config.ini** from `http-server-address = 127.0.0.1:8888` to `http-server-address = 0.0.0.0:8888`. This will enable port 8888 to listen on all ports, and that is needed because docker runs on a different network.
+
+This is part of the docker image, so this must be completed before running `bootstrap`. If you already have a docker image you can
+* Destroy the docker container
+* Remove docker image
+* Re-run bootstrap
+
+An alternative option is to enter the docker container, change the configuration, and restart the node.
+
+## DUNE Keys
+
+Once you follow the directions you need to grap the keys for the existing eosio account.
+
+```
+egrep 'priv_key|pub_key' src/dune/*.py
+```
+
+## Private Keys in Tests
+
+Look at `src/tests/node.js` and `src/tests/web.html` to make sure the private key matches DUNE's.
+
+## Start a Node
+
+Start a node if you haven't already
+```
+dune --start test_node
+```
+
+## Create Wallet
+
+Bit of a workaround here as of Aug 2022 there is a permissions problem. Workaround
+1 create an account that will fail
+2 new account created wallet
+3 change permissions on wallet
+
+### Create An Account Will Fail
+```
+dune --create-account thiswillfail
+Creating account [nodeone] with key pair [Private: 5K4GCQPREhc6HmJ2wWNqRHvVNSL1bZ79hu8grtmkUhGJcndUfMg, Public: EOS8DMcuK28sN7jw8Uj5gEKtH8JxdbhovhVkDaUoQAemo49RBse97]
+Error 3120006: No available wallet
+Ensure that you have created a wallet and have it open
+Error Details:
+You don't have any wallet!
+Stack Trace:
+wallet_manager.cpp:140 get_public_keys
+```
+
+### Change Permissions on Docker Container
+
+```
+docker exec -u root -it dune_container cp /root/eosio-wallet/default.wallet /home/www-data/eosio-wallet/
+docker exec -u root -it dune_container chown www-data:www-data /home/www-data/eosio-wallet/default.wallet
+```
+
+## Create Accounts
+
+Now we can create our test accounts. In the examples below replace, **priv_key** and **pub_key** with the values from [DUNE Keys](#DUNE Keys)
+
+```
+dune --create-account bob eosio pub_key priv_key
+dune --create-account alice eosio pub_key priv_key
+```
+
+## Run Tests
+
+```
+yarn test node
+```

--- a/src/eosjs-jsonrpc.ts
+++ b/src/eosjs-jsonrpc.ts
@@ -22,6 +22,7 @@ export class JsonRpc implements AuthorityProvider, AbiProvider {
     public fetchBuiltin: (input?: Request | string, init?: RequestInit) => Promise<Response>;
 
     /**
+     * @param endpoint
      * @param args
      *    * `fetch`:
      *    * browsers: leave `null` or `undefined`

--- a/src/tests/node.js
+++ b/src/tests/node.js
@@ -3,8 +3,10 @@ const { JsSignatureProvider } = require('../../dist/eosjs-jssig');
 const fetch = require('node-fetch');
 const { TextEncoder, TextDecoder } = require('util');
 
-const privateKey = '5JuH9fCXmU3xbj8nRmhPZaVrxxXrdPaRmZLW1cznNTmTQR2Kg5Z'; // replace with "bob" account private key
-/* new accounts for testing can be created by unlocking a cleos wallet then calling: 
+const privateKey = '5JPJoZXizFVi19wHkboX5fwwEU2jZVvtSJpQkQu3uqgNu8LNdQN'; // replace with "bob" account private key
+/* new accounts for testing can be created
+ * see docs/5.-Testing and Building with DUNE.md
+ *      OR  by unlocking a cleos wallet then calling:
  * 1) cleos create key --to-console (copy this privateKey & publicKey)
  * 2) cleos wallet import 
  * 3) cleos create account bob publicKey

--- a/src/tests/web.html
+++ b/src/tests/web.html
@@ -6,8 +6,10 @@
         <script src='../../dist-web/eosjs-jsonrpc.js'></script>
         <script src='../../dist-web/eosjs-jssig.js'></script>
         <script>
-            const privateKey = '5JuH9fCXmU3xbj8nRmhPZaVrxxXrdPaRmZLW1cznNTmTQR2Kg5Z'; // replace with 'bob' account private key
-            /* new accounts for testing can be created by unlocking a cleos wallet then calling: 
+            const privateKey = '5JPJoZXizFVi19wHkboX5fwwEU2jZVvtSJpQkQu3uqgNu8LNdQN'; // replace with 'bob' account private key
+            /* new accounts for testing can be created
+             * see docs/4.-Testing and Building with DUNE
+             *     OR  by unlocking a cleos wallet then calling:
             * 1) cleos create key --to-console (copy this privateKey & publicKey)
             * 2) cleos wallet import 
             * 3) cleos create account bob publicKey


### PR DESCRIPTION
## Change Description
removed eos.io reference from README and CONTRIBUTING


## API Changes
NONE

## Documentation Additions
None - did remove link to example SWIFT app, because that code is not up to date, and no longer a good example
