### PR TITLE
Add send_transaction2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ const api = new Api({ rpc, signatureProvider, textDecoder: new TextDecoder(), te
 
 `transact()` is used to sign and push transactions onto the blockchain with an optional configuration object parameter.  This parameter can override the default value of `broadcast: true`, and can be used to fill TAPOS fields given `blocksBehind` and `expireSeconds`.  Given no configuration options, transactions are expected to be unpacked with TAPOS fields (`expiration`, `ref_block_num`, `ref_block_prefix`) and will automatically be broadcast onto the chain.
 
+With the introduction of Mandel v3.1 the retry transaction feature also adds 5 new optional fields to the configuration object:
+
+- `useOldRPC`: use old RPC `push_transaction`, rather than new RPC send_transaction
+- `useOldSendRPC`: use old RPC `/v1/chain/send_transaction`, rather than new RPC `/v1/chain/send_transaction2`
+- `returnFailureTrace`: return partial traces on failed transactions
+- `retryTrxNumBlocks`: request node to retry transaction until in a block of given height, blocking call
+- `retryIrreversible`: request node to retry transaction until it is irreversible or expires, blocking call
+
 ```js
 (async () => {
   const result = await api.transact({
@@ -105,6 +113,7 @@ const api = new Api({ rpc, signatureProvider, textDecoder: new TextDecoder(), te
   }, {
     blocksBehind: 3,
     expireSeconds: 30,
+    retryIrreversible: true
   });
   console.dir(result);
 })();

--- a/README.md
+++ b/README.md
@@ -112,8 +112,7 @@ With the introduction of Mandel v3.1 the retry transaction feature also adds 5 n
     }]
   }, {
     blocksBehind: 3,
-    expireSeconds: 30,
-    retryTrxNumBlocks: 30
+    expireSeconds: 30
   });
   console.dir(result);
 })();

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ With the introduction of Mandel v3.1 the retry transaction feature also adds 5 n
   }, {
     blocksBehind: 3,
     expireSeconds: 30,
-    retryIrreversible: true
+    retryTrxNumBlocks: 30
   });
   console.dir(result);
 })();

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "jest-fetch-mock": "^3.0.3",
     "none": "^1.0.0",
     "rimraf": "^3.0.2",
+    "text-encoding": "^0.7.0",
     "ts-jest": "^26.5.6",
     "ts-loader": "^9.2.3",
     "typedoc": "^0.23.5",

--- a/src/eosjs-api.ts
+++ b/src/eosjs-api.ts
@@ -240,7 +240,7 @@ export class Api {
             expireSeconds,
             useOldRPC = false,
             useOldSendRPC = false,
-            returnFailureTrace = false,
+            returnFailureTrace = true,
             retryTrxNumBlocks = 0,
             retryIrreversible = false
         }:
@@ -330,6 +330,12 @@ export class Api {
                 return this.sendSignedTransaction(pushTransactionArgs);
             } else if(useOldRPC) {
                 return this.pushSignedTransaction(pushTransactionArgs);
+            } else {
+                return this.sendSignedTransaction2({
+                    return_failure_trace: returnFailureTrace, 
+                    retry_trx: false,
+                    transaction: pushTransactionArgs
+                });
             }
         }
         return pushTransactionArgs;

--- a/src/eosjs-api.ts
+++ b/src/eosjs-api.ts
@@ -223,7 +223,8 @@ export class Api {
      * Named Parameters:
      *    * `broadcast`: broadcast this transaction?
      *    * `sign`: sign this transaction?
-     *    * `useOldSendRPC`: Use old RPC /v1/chain/send_transaction, rather than new RPC /v1/chain/send_transaction2
+     *    * `useOldRPC`: use old RPC push_transaction, rather than new RPC send_transaction
+     *    * `useOldSendRPC`: use old RPC /v1/chain/send_transaction, rather than new RPC /v1/chain/send_transaction2
      *    * `retryTrx`: retry this transaction?
      *    * `returnFailureTrace`: return failure trace for this transaction?
      *    * `retryTrxNumBlocks`: retry trx for X blocks, 0 for irreversible?

--- a/src/eosjs-api.ts
+++ b/src/eosjs-api.ts
@@ -223,8 +223,8 @@ export class Api {
      * Named Parameters:
      *    * `broadcast`: broadcast this transaction?
      *    * `sign`: sign this transaction?
-     *    * `useOldRPC`: use old RPC push_transaction, rather than new RPC send_transaction
-     *    * `useOldSendRPC`: use old RPC /v1/chain/send_transaction, rather than new RPC /v1/chain/send_transaction2
+     *    * `useOldRPC`: use old RPC push_transaction, rather than new RPC send_transaction?
+     *    * `useOldSendRPC`: use old RPC /v1/chain/send_transaction, rather than new RPC /v1/chain/send_transaction2?
      *    * `returnFailureTrace`: return partial traces on failed transactions?
      *    * `retryTrxNumBlocks`: request node to retry transaction until in a block of given height, blocking call?
      *    * `retryIrreversible`: request node to retry transaction until it is irreversible or expires, blocking call?

--- a/src/eosjs-jsonrpc.ts
+++ b/src/eosjs-jsonrpc.ts
@@ -5,7 +5,7 @@
 
 import { AbiProvider, AuthorityProvider, AuthorityProviderArgs, BinaryAbi } from './eosjs-api-interfaces';
 import { base64ToBinary, convertLegacyPublicKeys } from './eosjs-numeric';
-import { GetAbiResult, GetBlockResult, GetCodeResult, GetInfoResult, GetRawCodeAndAbiResult, PushTransactionArgs, GetBlockHeaderStateResult } from "./eosjs-rpc-interfaces" // tslint:disable-line
+import { GetAbiResult, GetBlockResult, GetCodeResult, GetInfoResult, GetRawCodeAndAbiResult, PushTransactionArgs, GetBlockHeaderStateResult, SendTransaction2Args } from "./eosjs-rpc-interfaces" // tslint:disable-line
 import { RpcError } from './eosjs-rpcerror';
 
 function arrayToHex(data: Uint8Array) {
@@ -209,6 +209,27 @@ export class JsonRpc implements AuthorityProvider, AbiProvider {
             compression: 0,
             packed_context_free_data: arrayToHex(serializedContextFreeData || new Uint8Array(0)),
             packed_trx: arrayToHex(serializedTransaction),
+        });
+    }
+
+    /** Send a serialized transaction2 */
+    public async send_transaction2(
+        { 
+            return_failure_trace, 
+            retry_trx, retry_trx_num_blocks, 
+            transaction: { signatures, serializedTransaction, serializedContextFreeData } 
+        }: SendTransaction2Args
+    ): Promise<any> {
+        return await this.fetch('/v1/chain/send_transaction2', {
+            return_failure_trace,
+            retry_trx,
+            retry_trx_num_blocks,
+            transaction: {
+                signatures,
+                compression: 0,
+                packed_context_free_data: arrayToHex(serializedContextFreeData || new Uint8Array(0)),
+                packed_trx: arrayToHex(serializedTransaction),
+            }
         });
     }
 

--- a/src/eosjs-jsonrpc.ts
+++ b/src/eosjs-jsonrpc.ts
@@ -216,7 +216,8 @@ export class JsonRpc implements AuthorityProvider, AbiProvider {
     public async send_transaction2(
         { 
             return_failure_trace, 
-            retry_trx, retry_trx_num_blocks, 
+            retry_trx, 
+            retry_trx_num_blocks, 
             transaction: { signatures, serializedTransaction, serializedContextFreeData } 
         }: SendTransaction2Args
     ): Promise<any> {

--- a/src/eosjs-rpc-interfaces.ts
+++ b/src/eosjs-rpc-interfaces.ts
@@ -133,6 +133,6 @@ export interface PushTransactionArgs {
 export interface SendTransaction2Args {
     return_failure_trace: boolean,
     retry_trx: boolean,
-    retry_trx_num_blocks: number,
+    retry_trx_num_blocks?: number,
     transaction: PushTransactionArgs
 }

--- a/src/eosjs-rpc-interfaces.ts
+++ b/src/eosjs-rpc-interfaces.ts
@@ -105,6 +105,14 @@ export interface GetInfoResult {
     virtual_block_net_limit: number;
     block_cpu_limit: number;
     block_net_limit: number;
+    server_version_string: string;
+    fork_db_head_block_num: number,
+    fork_db_head_block_id: string,
+    server_full_version_string: string,
+    total_cpu_weight: string,
+    total_net_weight: string,
+    earliest_available_block_num: number,
+    last_irreversible_block_time: string
 }
 
 /** Return value of `/v1/chain/get_raw_code_and_abi` */

--- a/src/eosjs-rpc-interfaces.ts
+++ b/src/eosjs-rpc-interfaces.ts
@@ -120,3 +120,11 @@ export interface PushTransactionArgs {
     serializedTransaction: Uint8Array;
     serializedContextFreeData?: Uint8Array;
 }
+
+/** Arguments for `send_transaction2` */
+export interface SendTransaction2Args {
+    return_failure_trace: boolean,
+    retry_trx: boolean,
+    retry_trx_num_blocks: number,
+    transaction: PushTransactionArgs
+}

--- a/src/tests/eosjs-jsonrpc.test.ts
+++ b/src/tests/eosjs-jsonrpc.test.ts
@@ -606,6 +606,50 @@ describe('JSON RPC', () => {
         expect(fetch).toBeCalledWith(endpoint + expPath, expParams);
     });
 
+    it('calls send_transaction2', async () => {
+        const expPath = '/v1/chain/send_transaction2';
+        const signatures = [
+            'George Washington',
+            'John Hancock',
+            'Abraham Lincoln',
+        ];
+        const serializedTransaction = new Uint8Array([
+            0, 16, 32, 128, 255,
+        ]);
+
+        const expReturn = { data: '12345' };
+        const callParams = {
+            return_failure_trace: false,
+            retry_trx: false,
+            retry_trx_num_blocks: 0,
+            transaction: {
+                signatures,
+                serializedTransaction,
+            }
+        };
+        const expParams = {
+            body: JSON.stringify({
+                return_failure_trace: false,
+                retry_trx: false,
+                retry_trx_num_blocks: 0,
+                transaction: {
+                    signatures,
+                    compression: 0,
+                    packed_context_free_data: '',
+                    packed_trx: '00102080ff',
+                }
+            }),
+            method: 'POST',
+        };
+
+        fetchMock.once(JSON.stringify(expReturn));
+
+        const response = await jsonRpc.send_transaction2(callParams);
+
+        expect(response).toEqual(expReturn);
+        expect(fetch).toBeCalledWith(endpoint + expPath, expParams);
+    });
+
     it('calls db_size_get', async () => {
         const expPath = '/v1/db_size/get';
         const expReturn = { data: '12345' };

--- a/src/tests/eosjs-jsonrpc.test.ts
+++ b/src/tests/eosjs-jsonrpc.test.ts
@@ -606,7 +606,7 @@ describe('JSON RPC', () => {
         expect(fetch).toBeCalledWith(endpoint + expPath, expParams);
     });
 
-    it('calls send_transaction2', async () => {
+    it('calls send_transaction2 irreversible', async () => {
         const expPath = '/v1/chain/send_transaction2';
         const signatures = [
             'George Washington',
@@ -621,7 +621,6 @@ describe('JSON RPC', () => {
         const callParams = {
             return_failure_trace: false,
             retry_trx: false,
-            retry_trx_num_blocks: 0,
             transaction: {
                 signatures,
                 serializedTransaction,
@@ -631,7 +630,50 @@ describe('JSON RPC', () => {
             body: JSON.stringify({
                 return_failure_trace: false,
                 retry_trx: false,
-                retry_trx_num_blocks: 0,
+                transaction: {
+                    signatures,
+                    compression: 0,
+                    packed_context_free_data: '',
+                    packed_trx: '00102080ff',
+                }
+            }),
+            method: 'POST',
+        };
+
+        fetchMock.once(JSON.stringify(expReturn));
+
+        const response = await jsonRpc.send_transaction2(callParams);
+
+        expect(response).toEqual(expReturn);
+        expect(fetch).toBeCalledWith(endpoint + expPath, expParams);
+    });
+
+    it('calls send_transaction2 10 blocks', async () => {
+        const expPath = '/v1/chain/send_transaction2';
+        const signatures = [
+            'George Washington',
+            'John Hancock',
+            'Abraham Lincoln',
+        ];
+        const serializedTransaction = new Uint8Array([
+            0, 16, 32, 128, 255,
+        ]);
+
+        const expReturn = { data: '12345' };
+        const callParams = {
+            return_failure_trace: false,
+            retry_trx: false,
+            retry_trx_num_blocks: 10,
+            transaction: {
+                signatures,
+                serializedTransaction,
+            }
+        };
+        const expParams = {
+            body: JSON.stringify({
+                return_failure_trace: false,
+                retry_trx: false,
+                retry_trx_num_blocks: 10,
                 transaction: {
                     signatures,
                     compression: 0,

--- a/src/tests/node.js
+++ b/src/tests/node.js
@@ -85,6 +85,29 @@ const transactWithoutBroadcast = async () => await api.transact({
     blocksBehind: 3,
     expireSeconds: 30,
 });
+    
+
+const transactWithRetry = async () => await api.transact({
+  actions: [{
+        account: 'eosio.token',
+        name: 'transfer',
+        authorization: [{
+            actor: 'bob',
+            permission: 'active',
+        }],
+        data: {
+            from: 'bob',
+            to: 'alice',
+            quantity: '0.0001 SYS',
+            memo: '',
+        },
+    }]
+}, {
+    broadcast: false,
+    blocksBehind: 3,
+    expireSeconds: 30,
+    retryTrx: true
+});
 
 const broadcastResult = async (signaturesAndPackedTransaction) => await api.pushSignedTransaction(signaturesAndPackedTransaction);
 
@@ -111,6 +134,7 @@ module.exports = {
     transactWithConfig,
     transactWithoutConfig,
     transactWithoutBroadcast,
+    transactWithRetry,
     broadcastResult,
     transactShouldFail,
     rpcShouldFail

--- a/src/tests/node.js
+++ b/src/tests/node.js
@@ -106,7 +106,29 @@ const transactWithRetry = async () => await api.transact({
     broadcast: false,
     blocksBehind: 3,
     expireSeconds: 30,
-    retryTrx: true
+    retryTrxNumBlocks: 10
+});
+    
+const transactWithRetryIrreversible = async () => await api.transact({
+  actions: [{
+        account: 'eosio.token',
+        name: 'transfer',
+        authorization: [{
+            actor: 'bob',
+            permission: 'active',
+        }],
+        data: {
+            from: 'bob',
+            to: 'alice',
+            quantity: '0.0001 SYS',
+            memo: '',
+        },
+    }]
+}, {
+    broadcast: false,
+    blocksBehind: 3,
+    expireSeconds: 30,
+    retryIrreversible: true
 });
 
 const broadcastResult = async (signaturesAndPackedTransaction) => await api.pushSignedTransaction(signaturesAndPackedTransaction);
@@ -135,6 +157,7 @@ module.exports = {
     transactWithoutConfig,
     transactWithoutBroadcast,
     transactWithRetry,
+    transactWithRetryIrreversible,
     broadcastResult,
     transactShouldFail,
     rpcShouldFail

--- a/src/tests/node.test.ts
+++ b/src/tests/node.test.ts
@@ -33,6 +33,12 @@ describe('Node JS environment', () => {
         expect(Object.keys(transactionResponse)).toContain('transaction_id');
     });
 
+    it('retry transaction irreversible', async () => {
+        transactionSignatures = await tests.transactWithRetryIrreversible();
+        transactionResponse = await tests.broadcastResult(transactionSignatures);
+        expect(Object.keys(transactionResponse)).toContain('transaction_id');
+    });
+
     it('throws appropriate error message without configuration object or TAPOS in place', async () => {
         try {
             failedAsPlanned = true;

--- a/src/tests/node.test.ts
+++ b/src/tests/node.test.ts
@@ -27,6 +27,12 @@ describe('Node JS environment', () => {
         expect(Object.keys(transactionResponse)).toContain('transaction_id');
     });
 
+    it('retry transaction', async () => {
+        transactionSignatures = await tests.transactWithRetry();
+        transactionResponse = await tests.broadcastResult(transactionSignatures);
+        expect(Object.keys(transactionResponse)).toContain('transaction_id');
+    });
+
     it('throws appropriate error message without configuration object or TAPOS in place', async () => {
         try {
             failedAsPlanned = true;


### PR DESCRIPTION
This is one of my first open source contributions. I'm very open to feedback.

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Support Issue #5 
Related: https://github.com/eosnetworkfoundation/product/pull/30
- Added support for `/v1/chain/send_transaction2`.
- Added rpc unit test for `/v1/chain/send_transaction2`.
- Added `text-encoding` as dev dependency in package.json to run unit tests. 
- Update api.transaction to include options for retrying transaction
- Add error if `server_version_string` below `v3.1.0`
- Update `GetInfoResult` type with latest returned results
- Added `retry transaction` for `node.test.ts`

## API Changes
- added `returnFailureTrace` option, default false
- added `retryIrreversible` option, default false
- added `retryTrxNumBlocks` option, default 0
- added `useOldRPC` option, default false
- added `useOldSendRPC` option, default false
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- added documentation to the `README.md` file for 5 new API parameters.
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
