### PR TITLE
Corrected enf-eosjs in commonjs docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ import { JsSignatureProvider } from 'eosjs/dist/eosjs-jssig';           // devel
 
 Importing using commonJS syntax is supported by NodeJS out of the box.
 ```js
-const { Api, JsonRpc, RpcError } = require('eosjs');
+const { Api, JsonRpc, RpcError } = require('enf-eosjs');
 const fetch = require('node-fetch');                                    // node only; not needed in browsers
 const { TextEncoder, TextDecoder } = require('util');                   // node only; native TextEncoder/Decoder
 const { TextEncoder, TextDecoder } = require('text-encoding');          // React Native, IE11, and Edge Browsers only


### PR DESCRIPTION
## Change
Updated README.md and corrected library reference to _enf-eosjs_ in CommonJS section. 

Fixes #47

### Listing of Commits
3445e71 corrected enf-eosjs in commonjs docs

### Listing of Files Changed
README.md

### API Changes
None 

### Documentation Additions
Updated Readme 