### PR TITLE
Change calls to substr to use substring instead

### DIFF
--- a/src/eosjs-numeric.ts
+++ b/src/eosjs-numeric.ts
@@ -55,14 +55,14 @@ export const negate = (bignum: Uint8Array): void => {
 };
 
 /**
- * Convert an unsigned decimal number in `s` to a bignum
+ * Convert an unsigned decimal number in `str` to a bignum
  *
  * @param size bignum size (bytes)
  */
-export const decimalToBinary = (size: number, s: string): Uint8Array => {
+export const decimalToBinary = (size: number, str: string): Uint8Array => {
     const result = new Uint8Array(size);
-    for (let i = 0; i < s.length; ++i) {
-        const srcDigit = s.charCodeAt(i);
+    for (let i = 0; i < str.length; ++i) {
+        const srcDigit = str.charCodeAt(i);
         if (srcDigit < '0'.charCodeAt(0) || srcDigit > '9'.charCodeAt(0)) {
             throw new Error('invalid number');
         }
@@ -80,16 +80,16 @@ export const decimalToBinary = (size: number, s: string): Uint8Array => {
 };
 
 /**
- * Convert a signed decimal number in `s` to a bignum
+ * Convert a signed decimal number in `str` to a bignum
  *
  * @param size bignum size (bytes)
  */
-export const signedDecimalToBinary = (size: number, s: string): Uint8Array => {
-    const negative = s[0] === '-';
+export const signedDecimalToBinary = (size: number, str: string): Uint8Array => {
+    const negative = str[0] === '-';
     if (negative) {
-        s = s.substring(1);
+        str = str.substring(1);
     }
-    const result = decimalToBinary(size, s);
+    const result = decimalToBinary(size, str);
     if (negative) {
         negate(result);
         if (!isNegative(result)) {
@@ -138,10 +138,10 @@ export const signedBinaryToDecimal = (bignum: Uint8Array, minDigits = 1): string
     return binaryToDecimal(bignum, minDigits);
 };
 
-const base58ToBinaryVarSize = (s: string): Uint8Array => {
+const base58ToBinaryVarSize = (str: string): Uint8Array => {
     const result = [] as number[];
-    for (let i = 0; i < s.length; ++i) {
-        let carry = base58Map[s.charCodeAt(i)];
+    for (let i = 0; i < str.length; ++i) {
+        let carry = base58Map[str.charCodeAt(i)];
         if (carry < 0) {
             throw new Error('invalid base-58 value');
         }
@@ -154,7 +154,7 @@ const base58ToBinaryVarSize = (s: string): Uint8Array => {
             result.push(carry);
         }
     }
-    for (const ch of s) {
+    for (const ch of str) {
         if (ch === '1') {
             result.push(0);
         } else {
@@ -166,17 +166,17 @@ const base58ToBinaryVarSize = (s: string): Uint8Array => {
 };
 
 /**
- * Convert an unsigned base-58 number in `s` to a bignum
+ * Convert an unsigned base-58 number in `str` to a bignum
  *
  * @param size bignum size (bytes)
  */
-export const base58ToBinary = (size: number, s: string): Uint8Array => {
+export const base58ToBinary = (size: number, str: string): Uint8Array => {
     if (!size) {
-        return base58ToBinaryVarSize(s);
+        return base58ToBinaryVarSize(str);
     }
     const result = new Uint8Array(size);
-    for (let i = 0; i < s.length; ++i) {
-        let carry = base58Map[s.charCodeAt(i)];
+    for (let i = 0; i < str.length; ++i) {
+        let carry = base58Map[str.charCodeAt(i)];
         if (carry < 0) {
             throw new Error('invalid base-58 value');
         }
@@ -223,10 +223,10 @@ export const binaryToBase58 = (bignum: Uint8Array, minDigits = 1): string => {
     return String.fromCharCode(...result);
 };
 
-/** Convert an unsigned base-64 number in `s` to a bignum */
-export const base64ToBinary = (s: string): Uint8Array => {
-    let len = s.length;
-    if ((len & 3) === 1 && s[len - 1] === '=') {
+/** Convert an unsigned base-64 number in `str` to a bignum */
+export const base64ToBinary = (str: string): Uint8Array => {
+    let len = str.length;
+    if ((len & 3) === 1 && str[len - 1] === '=') {
         len -= 1;
     } // fc appends an extra '='
     if ((len & 3) !== 0) {
@@ -234,8 +234,8 @@ export const base64ToBinary = (s: string): Uint8Array => {
     }
     const groups = len >> 2;
     let bytes = groups * 3;
-    if (len > 0 && s[len - 1] === '=') {
-        if (s[len - 2] === '=') {
+    if (len > 0 && str[len - 1] === '=') {
+        if (str[len - 2] === '=') {
             bytes -= 2;
         } else {
             bytes -= 1;
@@ -244,10 +244,10 @@ export const base64ToBinary = (s: string): Uint8Array => {
     const result = new Uint8Array(bytes);
 
     for (let group = 0; group < groups; ++group) {
-        const digit0 = base64Map[s.charCodeAt(group * 4 + 0)];
-        const digit1 = base64Map[s.charCodeAt(group * 4 + 1)];
-        const digit2 = base64Map[s.charCodeAt(group * 4 + 2)];
-        const digit3 = base64Map[s.charCodeAt(group * 4 + 3)];
+        const digit0 = base64Map[str.charCodeAt(group * 4 + 0)];
+        const digit1 = base64Map[str.charCodeAt(group * 4 + 1)];
+        const digit2 = base64Map[str.charCodeAt(group * 4 + 2)];
+        const digit3 = base64Map[str.charCodeAt(group * 4 + 3)];
         result[group * 3 + 0] = (digit0 << 2) | (digit1 >> 4);
         if (group * 3 + 1 < bytes) {
             result[group * 3 + 1] = ((digit1 & 15) << 4) | (digit2 >> 2);
@@ -315,13 +315,13 @@ const keyToString = (key: Key, suffix: string, prefix: string): string => {
     return prefix + binaryToBase58(whole);
 };
 
-/** Convert key in `s` to binary form */
-export const stringToPublicKey = (s: string): Key => {
-    if (typeof s !== 'string') {
+/** Convert key in `str` to binary form */
+export const stringToPublicKey = (str: string): Key => {
+    if (typeof str !== 'string') {
         throw new Error('expected string containing public key');
     }
-    if (s.substring(0, 3) === 'EOS') {
-        const whole = base58ToBinary(publicKeyDataSize + 4, s.substring(3));
+    if (str.substring(0, 3) === 'EOS') {
+        const whole = base58ToBinary(publicKeyDataSize + 4, str.substring(3));
         const key = { type: KeyType.k1, data: new Uint8Array(publicKeyDataSize) };
         for (let i = 0; i < publicKeyDataSize; ++i) {
             key.data[i] = whole[i];
@@ -332,12 +332,12 @@ export const stringToPublicKey = (s: string): Key => {
             throw new Error('checksum doesn\'t match');
         }
         return key;
-    } else if (s.substring(0, 7) === 'PUB_K1_') {
-        return stringToKey(s.substring(7), KeyType.k1, publicKeyDataSize, 'K1');
-    } else if (s.substring(0, 7) === 'PUB_R1_') {
-        return stringToKey(s.substring(7), KeyType.r1, publicKeyDataSize, 'R1');
-    } else if (s.substring(0, 7) === 'PUB_WA_') {
-        return stringToKey(s.substring(7), KeyType.wa, 0, 'WA');
+    } else if (str.substring(0, 7) === 'PUB_K1_') {
+        return stringToKey(str.substring(7), KeyType.k1, publicKeyDataSize, 'K1');
+    } else if (str.substring(0, 7) === 'PUB_R1_') {
+        return stringToKey(str.substring(7), KeyType.r1, publicKeyDataSize, 'R1');
+    } else if (str.substring(0, 7) === 'PUB_WA_') {
+        return stringToKey(str.substring(7), KeyType.wa, 0, 'WA');
     } else {
         throw new Error('unrecognized public key format');
     }
@@ -370,11 +370,11 @@ export const publicKeyToString = (key: Key): string => {
 /** If a key is in the legacy format (`EOS` prefix), then convert it to the new format (`PUB_K1_`).
  * Leaves other formats untouched
  */
-export const convertLegacyPublicKey = (s: string): string => {
-    if (s.substring(0, 3) === 'EOS') {
-        return publicKeyToString(stringToPublicKey(s));
+export const convertLegacyPublicKey = (str: string): string => {
+    if (str.substring(0, 3) === 'EOS') {
+        return publicKeyToString(stringToPublicKey(str));
     }
-    return s;
+    return str;
 };
 
 /** If a key is in the legacy format (`EOS` prefix), then convert it to the new format (`PUB_K1_`).
@@ -384,20 +384,20 @@ export const convertLegacyPublicKeys = (keys: string[]): string[] => {
     return keys.map(convertLegacyPublicKey);
 };
 
-/** Convert key in `s` to binary form */
-export const stringToPrivateKey = (s: string): Key => {
-    if (typeof s !== 'string') {
+/** Convert key in `str` to binary form */
+export const stringToPrivateKey = (str: string): Key => {
+    if (typeof str !== 'string') {
         throw new Error('expected string containing private key');
     }
-    if (s.substring(0, 7) === 'PVT_R1_') {
-        return stringToKey(s.substring(7), KeyType.r1, privateKeyDataSize, 'R1');
-    } else if (s.substring(0, 7) === 'PVT_K1_') {
-        return stringToKey(s.substring(7), KeyType.k1, privateKeyDataSize, 'K1');
+    if (str.substring(0, 7) === 'PVT_R1_') {
+        return stringToKey(str.substring(7), KeyType.r1, privateKeyDataSize, 'R1');
+    } else if (str.substring(0, 7) === 'PVT_K1_') {
+        return stringToKey(str.substring(7), KeyType.k1, privateKeyDataSize, 'K1');
     } else {
         // todo: Verify checksum: sha256(sha256(key.data)).
         //       Not critical since a bad key will fail to produce a
         //       valid signature anyway.
-        const whole = base58ToBinary(privateKeyDataSize + 5, s);
+        const whole = base58ToBinary(privateKeyDataSize + 5, str);
         const key = { type: KeyType.k1, data: new Uint8Array(privateKeyDataSize) };
         if (whole[0] !== 0x80) {
             throw new Error('unrecognized private key type');
@@ -447,17 +447,17 @@ export const privateKeyToString = (key: Key): string => {
     }
 };
 
-/** Convert key in `s` to binary form */
-export const stringToSignature = (s: string): Key => {
-    if (typeof s !== 'string') {
+/** Convert key in `str` to binary form */
+export const stringToSignature = (str: string): Key => {
+    if (typeof str !== 'string') {
         throw new Error('expected string containing signature');
     }
-    if (s.substring(0, 7) === 'SIG_K1_') {
-        return stringToKey(s.substring(7), KeyType.k1, signatureDataSize, 'K1');
-    } else if (s.substring(0, 7) === 'SIG_R1_') {
-        return stringToKey(s.substring(7), KeyType.r1, signatureDataSize, 'R1');
-    } else if (s.substring(0, 7) === 'SIG_WA_') {
-        return stringToKey(s.substring(7), KeyType.wa, 0, 'WA');
+    if (str.substring(0, 7) === 'SIG_K1_') {
+        return stringToKey(str.substring(7), KeyType.k1, signatureDataSize, 'K1');
+    } else if (str.substring(0, 7) === 'SIG_R1_') {
+        return stringToKey(str.substring(7), KeyType.r1, signatureDataSize, 'R1');
+    } else if (str.substring(0, 7) === 'SIG_WA_') {
+        return stringToKey(str.substring(7), KeyType.wa, 0, 'WA');
     } else {
         throw new Error('unrecognized signature format');
     }

--- a/src/eosjs-numeric.ts
+++ b/src/eosjs-numeric.ts
@@ -87,7 +87,7 @@ export const decimalToBinary = (size: number, s: string): Uint8Array => {
 export const signedDecimalToBinary = (size: number, s: string): Uint8Array => {
     const negative = s[0] === '-';
     if (negative) {
-        s = s.substr(1);
+        s = s.substring(1);
     }
     const result = decimalToBinary(size, s);
     if (negative) {
@@ -320,8 +320,8 @@ export const stringToPublicKey = (s: string): Key => {
     if (typeof s !== 'string') {
         throw new Error('expected string containing public key');
     }
-    if (s.substr(0, 3) === 'EOS') {
-        const whole = base58ToBinary(publicKeyDataSize + 4, s.substr(3));
+    if (s.substring(0, 3) === 'EOS') {
+        const whole = base58ToBinary(publicKeyDataSize + 4, s.substring(3));
         const key = { type: KeyType.k1, data: new Uint8Array(publicKeyDataSize) };
         for (let i = 0; i < publicKeyDataSize; ++i) {
             key.data[i] = whole[i];
@@ -332,12 +332,12 @@ export const stringToPublicKey = (s: string): Key => {
             throw new Error('checksum doesn\'t match');
         }
         return key;
-    } else if (s.substr(0, 7) === 'PUB_K1_') {
-        return stringToKey(s.substr(7), KeyType.k1, publicKeyDataSize, 'K1');
-    } else if (s.substr(0, 7) === 'PUB_R1_') {
-        return stringToKey(s.substr(7), KeyType.r1, publicKeyDataSize, 'R1');
-    } else if (s.substr(0, 7) === 'PUB_WA_') {
-        return stringToKey(s.substr(7), KeyType.wa, 0, 'WA');
+    } else if (s.substring(0, 7) === 'PUB_K1_') {
+        return stringToKey(s.substring(7), KeyType.k1, publicKeyDataSize, 'K1');
+    } else if (s.substring(0, 7) === 'PUB_R1_') {
+        return stringToKey(s.substring(7), KeyType.r1, publicKeyDataSize, 'R1');
+    } else if (s.substring(0, 7) === 'PUB_WA_') {
+        return stringToKey(s.substring(7), KeyType.wa, 0, 'WA');
     } else {
         throw new Error('unrecognized public key format');
     }
@@ -371,7 +371,7 @@ export const publicKeyToString = (key: Key): string => {
  * Leaves other formats untouched
  */
 export const convertLegacyPublicKey = (s: string): string => {
-    if (s.substr(0, 3) === 'EOS') {
+    if (s.substring(0, 3) === 'EOS') {
         return publicKeyToString(stringToPublicKey(s));
     }
     return s;
@@ -389,10 +389,10 @@ export const stringToPrivateKey = (s: string): Key => {
     if (typeof s !== 'string') {
         throw new Error('expected string containing private key');
     }
-    if (s.substr(0, 7) === 'PVT_R1_') {
-        return stringToKey(s.substr(7), KeyType.r1, privateKeyDataSize, 'R1');
-    } else if (s.substr(0, 7) === 'PVT_K1_') {
-        return stringToKey(s.substr(7), KeyType.k1, privateKeyDataSize, 'K1');
+    if (s.substring(0, 7) === 'PVT_R1_') {
+        return stringToKey(s.substring(7), KeyType.r1, privateKeyDataSize, 'R1');
+    } else if (s.substring(0, 7) === 'PVT_K1_') {
+        return stringToKey(s.substring(7), KeyType.k1, privateKeyDataSize, 'K1');
     } else {
         // todo: Verify checksum: sha256(sha256(key.data)).
         //       Not critical since a bad key will fail to produce a
@@ -452,12 +452,12 @@ export const stringToSignature = (s: string): Key => {
     if (typeof s !== 'string') {
         throw new Error('expected string containing signature');
     }
-    if (s.substr(0, 7) === 'SIG_K1_') {
-        return stringToKey(s.substr(7), KeyType.k1, signatureDataSize, 'K1');
-    } else if (s.substr(0, 7) === 'SIG_R1_') {
-        return stringToKey(s.substr(7), KeyType.r1, signatureDataSize, 'R1');
-    } else if (s.substr(0, 7) === 'SIG_WA_') {
-        return stringToKey(s.substr(7), KeyType.wa, 0, 'WA');
+    if (s.substring(0, 7) === 'SIG_K1_') {
+        return stringToKey(s.substring(7), KeyType.k1, signatureDataSize, 'K1');
+    } else if (s.substring(0, 7) === 'SIG_R1_') {
+        return stringToKey(s.substring(7), KeyType.r1, signatureDataSize, 'R1');
+    } else if (s.substring(0, 7) === 'SIG_WA_') {
+        return stringToKey(s.substring(7), KeyType.wa, 0, 'WA');
     } else {
         throw new Error('unrecognized signature format');
     }

--- a/src/eosjs-serialize.ts
+++ b/src/eosjs-serialize.ts
@@ -447,36 +447,36 @@ export class SerialBuffer { // tslint:disable-line max-classes-per-file
     }
 
     /** Append an asset */
-    public pushAsset(s: string) {
-        if (typeof s !== 'string') {
+    public pushAsset(str: string) {
+        if (typeof str !== 'string') {
             throw new Error('Expected string containing asset');
         }
-        s = s.trim();
+        str = str.trim();
         let pos = 0;
         let amount = '';
         let precision = 0;
-        if (s[pos] === '-') {
+        if (str[pos] === '-') {
             amount += '-';
             ++pos;
         }
         let foundDigit = false;
-        while (pos < s.length && s.charCodeAt(pos) >= '0'.charCodeAt(0) && s.charCodeAt(pos) <= '9'.charCodeAt(0)) {
+        while (pos < str.length && str.charCodeAt(pos) >= '0'.charCodeAt(0) && str.charCodeAt(pos) <= '9'.charCodeAt(0)) {
             foundDigit = true;
-            amount += s[pos];
+            amount += str[pos];
             ++pos;
         }
         if (!foundDigit) {
             throw new Error('Asset must begin with a number');
         }
-        if (s[pos] === '.') {
+        if (str[pos] === '.') {
             ++pos;
-            while (pos < s.length && s.charCodeAt(pos) >= '0'.charCodeAt(0) && s.charCodeAt(pos) <= '9'.charCodeAt(0)) {
-                amount += s[pos];
+            while (pos < str.length && str.charCodeAt(pos) >= '0'.charCodeAt(0) && str.charCodeAt(pos) <= '9'.charCodeAt(0)) {
+                amount += str[pos];
                 ++precision;
                 ++pos;
             }
         }
-        const name = s.substring(pos).trim();
+        const name = str.substring(pos).trim();
         this.pushArray(numeric.signedDecimalToBinary(8, amount));
         this.pushSymbol({ name, precision });
     }
@@ -485,12 +485,12 @@ export class SerialBuffer { // tslint:disable-line max-classes-per-file
     public getAsset() {
         const amount = this.getUint8Array(8);
         const { name, precision } = this.getSymbol();
-        let s = numeric.signedBinaryToDecimal(amount, precision + 1);
+        let decimalString = numeric.signedBinaryToDecimal(amount, precision + 1);
         if (precision) {
             // precision could be more than length here.
-            s = s.substring(0, s.length - precision) + '.' + s.substring(s.length - precision);
+            decimalString = decimalString.substring(0, decimalString.length - precision) + '.' + decimalString.substring(decimalString.length - precision);
         }
-        return s + ' ' + name;
+        return decimalString + ' ' + name;
     }
 
     /** Append a public key */
@@ -573,8 +573,8 @@ export function dateToTimePoint(date: string) {
 
 /** Convert `time_point` (miliseconds since epoch) to date in ISO format */
 export function timePointToDate(us: number) {
-    const s = (new Date(us / 1000)).toISOString();
-    return s.substring(0, s.length - 1);
+    const isoString = (new Date(us / 1000)).toISOString();
+    return isoString.substring(0, isoString.length - 1);
 }
 
 /** Convert date in ISO format to `time_point_sec` (seconds since epoch) */
@@ -584,8 +584,8 @@ export function dateToTimePointSec(date: string) {
 
 /** Convert `time_point_sec` (seconds since epoch) to date in ISO format and trim the ending "Z" */
 export function timePointSecToDate(sec: number) {
-    const s = (new Date(sec * 1000)).toISOString();
-    return s.substring(0, s.length - 1);
+    const isoString = (new Date(sec * 1000)).toISOString();
+    return isoString.substring(0, isoString.length - 1);
 }
 
 /** Convert date in ISO format to `block_timestamp_type` (half-seconds since a different epoch) */
@@ -595,8 +595,8 @@ export function dateToBlockTimestamp(date: string) {
 
 /** Convert `block_timestamp_type` (half-seconds since a different epoch) to to date in ISO format */
 export function blockTimestampToDate(slot: number) {
-    const s = (new Date(slot * 500 + 946684800000)).toISOString();
-    return s.substring(0, s.length - 1);
+    const isoString = (new Date(slot * 500 + 946684800000)).toISOString();
+    return isoString.substring(0, isoString.length - 1);
 }
 
 /** Convert `string` to `Symbol`. format: `precision,NAME`. */
@@ -1082,8 +1082,8 @@ export function getTypesFromAbi(initialTypes: Map<string, Type>, abi: Abi) {
     return types;
 } // getTypesFromAbi
 
-function reverseHex(h: string) {
-    return h.substring(6, 8) + h.substring(4, 6) + h.substring(2, 4) + h.substring(0, 2);
+function reverseHex(hex: string) {
+    return hex.substring(6, 8) + hex.substring(4, 6) + hex.substring(2, 4) + hex.substring(0, 2);
 }
 
 /** TAPoS: Return transaction fields which reference `refBlock` and expire `expireSeconds` after `timestamp` */

--- a/src/eosjs-serialize.ts
+++ b/src/eosjs-serialize.ts
@@ -370,7 +370,7 @@ export class SerialBuffer { // tslint:disable-line max-classes-per-file
         }
         // removals all trailing dots
         while (result.endsWith('.')) {
-            result = result.substr(0, result.length - 1);
+            result = result.substring(0, result.length - 1);
         }
         return result;
     }
@@ -476,7 +476,7 @@ export class SerialBuffer { // tslint:disable-line max-classes-per-file
                 ++pos;
             }
         }
-        const name = s.substr(pos).trim();
+        const name = s.substring(pos).trim();
         this.pushArray(numeric.signedDecimalToBinary(8, amount));
         this.pushSymbol({ name, precision });
     }
@@ -487,7 +487,8 @@ export class SerialBuffer { // tslint:disable-line max-classes-per-file
         const { name, precision } = this.getSymbol();
         let s = numeric.signedBinaryToDecimal(amount, precision + 1);
         if (precision) {
-            s = s.substr(0, s.length - precision) + '.' + s.substr(s.length - precision);
+            // precision could be more than length here.
+            s = s.substring(0, s.length - precision) + '.' + s.substring(s.length - precision);
         }
         return s + ' ' + name;
     }
@@ -573,7 +574,7 @@ export function dateToTimePoint(date: string) {
 /** Convert `time_point` (miliseconds since epoch) to date in ISO format */
 export function timePointToDate(us: number) {
     const s = (new Date(us / 1000)).toISOString();
-    return s.substr(0, s.length - 1);
+    return s.substring(0, s.length - 1);
 }
 
 /** Convert date in ISO format to `time_point_sec` (seconds since epoch) */
@@ -581,10 +582,10 @@ export function dateToTimePointSec(date: string) {
     return Math.round(checkDateParse(date + 'Z') / 1000);
 }
 
-/** Convert `time_point_sec` (seconds since epoch) to to date in ISO format */
+/** Convert `time_point_sec` (seconds since epoch) to date in ISO format and trim the ending "Z" */
 export function timePointSecToDate(sec: number) {
     const s = (new Date(sec * 1000)).toISOString();
-    return s.substr(0, s.length - 1);
+    return s.substring(0, s.length - 1);
 }
 
 /** Convert date in ISO format to `block_timestamp_type` (half-seconds since a different epoch) */
@@ -595,7 +596,7 @@ export function dateToBlockTimestamp(date: string) {
 /** Convert `block_timestamp_type` (half-seconds since a different epoch) to to date in ISO format */
 export function blockTimestampToDate(slot: number) {
     const s = (new Date(slot * 500 + 946684800000)).toISOString();
-    return s.substr(0, s.length - 1);
+    return s.substring(0, s.length - 1);
 }
 
 /** Convert `string` to `Symbol`. format: `precision,NAME`. */
@@ -635,7 +636,8 @@ export function hexToUint8Array(hex: string) {
     const l = hex.length / 2;
     const result = new Uint8Array(l);
     for (let i = 0; i < l; ++i) {
-        const x = parseInt(hex.substr(i * 2, 2), 16);
+        const start = i * 2;
+        const x = parseInt(hex.substring(start, start + 2), 16);
         if (Number.isNaN(x)) {
             throw new Error('Expected hex string');
         }
@@ -1011,7 +1013,7 @@ export function getType(types: Map<string, Type>, name: string): Type {
     if (name.endsWith('[]')) {
         return createType({
             name,
-            arrayOf: getType(types, name.substr(0, name.length - 2)),
+            arrayOf: getType(types, name.substring(0, name.length - 2)),
             serialize: serializeArray,
             deserialize: deserializeArray,
         });
@@ -1019,7 +1021,7 @@ export function getType(types: Map<string, Type>, name: string): Type {
     if (name.endsWith('?')) {
         return createType({
             name,
-            optionalOf: getType(types, name.substr(0, name.length - 1)),
+            optionalOf: getType(types, name.substring(0, name.length - 1)),
             serialize: serializeOptional,
             deserialize: deserializeOptional,
         });
@@ -1027,7 +1029,7 @@ export function getType(types: Map<string, Type>, name: string): Type {
     if (name.endsWith('$')) {
         return createType({
             name,
-            extensionOf: getType(types, name.substr(0, name.length - 1)),
+            extensionOf: getType(types, name.substring(0, name.length - 1)),
             serialize: serializeExtension,
             deserialize: deserializeExtension,
         });
@@ -1081,13 +1083,13 @@ export function getTypesFromAbi(initialTypes: Map<string, Type>, abi: Abi) {
 } // getTypesFromAbi
 
 function reverseHex(h: string) {
-    return h.substr(6, 2) + h.substr(4, 2) + h.substr(2, 2) + h.substr(0, 2);
+    return h.substring(6, 8) + h.substring(4, 6) + h.substring(2, 4) + h.substring(0, 2);
 }
 
 /** TAPoS: Return transaction fields which reference `refBlock` and expire `expireSeconds` after `timestamp` */
 export function transactionHeader(refBlock: BlockTaposInfo, expireSeconds: number) {
     const timestamp = refBlock.header ? refBlock.header.timestamp : refBlock.timestamp;
-    const prefix = parseInt(reverseHex(refBlock.id.substr(16, 8)), 16);
+    const prefix = parseInt(reverseHex(refBlock.id.substring(16, 24)), 16);
 
     return {
         expiration: timePointSecToDate(dateToTimePointSec(timestamp) + expireSeconds),

--- a/src/tests/node.js
+++ b/src/tests/node.js
@@ -45,7 +45,7 @@ const transactWithoutConfig = async () => {
     const currentDate = new Date();
     const timePlusTen = currentDate.getTime() + 10000;
     const timeInISOString = (new Date(timePlusTen)).toISOString();
-    const expiration = timeInISOString.substr(0, timeInISOString.length - 1);
+    const expiration = timeInISOString.substring(0, timeInISOString.length - 1);
 
     return await api.transact({
         expiration,

--- a/src/tests/web.html
+++ b/src/tests/web.html
@@ -74,7 +74,7 @@
                 const currentDate = new Date();
                 const timePlusTen = currentDate.getTime() + 10000;
                 const timeInISOString = (new Date(timePlusTen)).toISOString();
-                const expiration = timeInISOString.substr(0, timeInISOString.length - 1);
+                const expiration = timeInISOString.substring(0, timeInISOString.length - 1);
         
                 return await api.transact({
                     expiration,


### PR DESCRIPTION
## Change
Updating calls to substr to use substring instead. For the most part this is a straight forward change in our code and we can just replace "substr" with "substring" and call it a day. In some places where we do "substr(x, i)" where "x" is more than 0 and "i" is the amount of characters we want to include, we have to instead replace with "substring(x, i + x)".

### Listing of Commits
7c156ee (HEAD -> jm/20-substr, origin/jm/20-substr) Substr changed to substring

### Listing of Files Changed
<!-- git diff --name-only origin/main...origin/"jm/20-substr" -->
src/eosjs-numeric.ts
src/eosjs-serialize.ts
src/tests/node.js
src/tests/web.html

### API Changes
None

### Documentation Additions
None