### PR TITLE
rm semver package dep not avalible in nodejs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "bn.js": "5.2.0",
         "elliptic": "6.5.4",
         "hash.js": "1.1.7",
-        "node-fetch": "2.6.7",
-        "semver": "^7.3.7"
+        "node-fetch": "2.6.7"
       },
       "devDependencies": {
         "@types/elliptic": "^6.4.13",
@@ -8251,6 +8250,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -9827,6 +9827,7 @@
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -11596,7 +11597,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yargs": {
       "version": "15.4.1",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "bn.js": "5.2.0",
     "elliptic": "6.5.4",
     "hash.js": "1.1.7",
-    "node-fetch": "2.6.7",
-    "semver": "^7.3.7"
+    "node-fetch": "2.6.7"
   },
   "devDependencies": {
     "@types/elliptic": "^6.4.13",

--- a/src/ChainSemanticVersion.ts
+++ b/src/ChainSemanticVersion.ts
@@ -45,11 +45,13 @@ export class ChainSemanticVersion {
         return (
             // better then 4 ok!
             versionObject.major > 4 ||
+            (versionObject.major == 4 && versionObject.minor > 0) ||
             // RC versions of v4.0.0 will not work. RC version of other version will work
+            // Treat patch level undefined as patch level 0
             (versionObject.major == 4 &&
                 !(
                     versionObject.minor == 0 &&
-                    versionObject.patch == 0 &&
+                    (versionObject.patch == 0 || versionObject.patch == null) &&
                     this.semverString.hasReleaseCandidate
                 ))
         )
@@ -82,7 +84,7 @@ export class ChainSemanticVersion {
     private getMajorMinorVersion(): MajorMinorPatch {
         const semVersions = this.semverString.version.split('.')
         // expect at least major and minor version
-        if (semVersions.length < 3) {
+        if (semVersions.length < 2) {
             this.semverString.parsingError = true
             return {major: 0, minor: 0}
         }
@@ -91,7 +93,7 @@ export class ChainSemanticVersion {
             this.semverString.parsingError = true
             return {major: 0, minor: 0}
         }
-        let patch = 0
+        let patch = undefined
         if (semVersions.length > 2 && !isNaN(parseInt(semVersions[2]))) {
             patch = parseInt(semVersions[2])
         }

--- a/src/ChainSemanticVersion.ts
+++ b/src/ChainSemanticVersion.ts
@@ -1,0 +1,100 @@
+interface CleanedVersion {
+    version: string
+    hasReleaseCandidate: boolean
+    parsingError: boolean
+}
+
+interface MajorMinorPatch {
+    major: number
+    minor: number
+    patch?: number
+}
+
+export class ChainSemanticVersion {
+    public semverString: CleanedVersion
+
+    /**
+     *
+     * @param info is a version string, starts with 'v' and followed by semver seperated by '. Example 'v4.0.1'
+     *
+     */
+    constructor(info: string) {
+        this.semverString = this.stripReleaseCandidate(this.stripLeadingV(info))
+    }
+
+    public supportsLeap3Features(): boolean {
+        const versionObject = this.getMajorMinorVersion()
+        // must be major version 3 with minor version 1 or better
+        // note v3.1.0-rc1 is a pre-v3.1.0 release and does not support 3.0 features
+        return (
+            // better then 3 ok!
+            versionObject.major > 3 ||
+            // version 3 must be version 1 or better
+            (versionObject.major == 3 &&
+                ((versionObject.minor == 1 && !this.semverString.hasReleaseCandidate)
+                ||
+                versionObject.minor > 1)
+            )
+        )
+    }
+
+    public supportsLeap4Features(): boolean {
+        const versionObject = this.getMajorMinorVersion()
+        // must be major version 4 with minor version 0 or better
+        // note v4.0.0-rc1 is a pre-v4.0.0 release and does not support 4.0 features
+        return (
+            // better then 4 ok!
+            versionObject.major > 4 ||
+            // RC versions of v4.0.0 will not work. RC version of other version will work
+            (versionObject.major == 4 &&
+                !(
+                    versionObject.minor == 0 &&
+                    versionObject.patch == 0 &&
+                    this.semverString.hasReleaseCandidate
+                ))
+        )
+    }
+
+    private stripLeadingV(info: string): string {
+        if (info.startsWith('v')) {
+            return info.slice(1)
+        } else {
+            return info
+        }
+    }
+
+    private stripReleaseCandidate(info: string): CleanedVersion {
+        const versionString = info.split('-')
+        if (versionString.length > 1) {
+            return {
+                version: versionString[0],
+                hasReleaseCandidate: true,
+                parsingError: false,
+            }
+        }
+        return {
+            version: info,
+            hasReleaseCandidate: false,
+            parsingError: false,
+        }
+    }
+
+    private getMajorMinorVersion(): MajorMinorPatch {
+        const semVersions = this.semverString.version.split('.')
+        // expect at least major and minor version
+        if (semVersions.length < 3) {
+            this.semverString.parsingError = true
+            return {major: 0, minor: 0}
+        }
+        // expect a number
+        if (isNaN(parseInt(semVersions[0])) || isNaN(parseInt(semVersions[1]))) {
+            this.semverString.parsingError = true
+            return {major: 0, minor: 0}
+        }
+        let patch = 0
+        if (semVersions.length > 2 && !isNaN(parseInt(semVersions[2]))) {
+            patch = parseInt(semVersions[2])
+        }
+        return {major: parseInt(semVersions[0]), minor: parseInt(semVersions[1]), patch: patch}
+    }
+}

--- a/src/tests/eosjs-util.test.ts
+++ b/src/tests/eosjs-util.test.ts
@@ -1,0 +1,49 @@
+import {ChainSemanticVersion} from '../ChainSemanticVersion'
+
+const version3NoSupport = ['v3.1.0-rc4', 'v3.0.99-rc1', 'v3.0.99']
+const version3WithSupport = [
+    'v3.2.0-rc1',
+    'v3.2.0-rc2',
+    'v3.2.0-rc3',
+    'v3.1.0',
+    'v3.1.1',
+    'v3.1.2',
+    'v3.1.3',
+    'v3.1.4',
+    'v3.2.0',
+    'v3.2.1',
+    'v3.2.2',
+    'v3.2.3',
+]
+const version4NoSupport = ['v4.0.0-rc1', 'v4.0.0-rc2', 'v4.0.0-rc3']
+const version4WithSupport = ['v4.0.0', 'v4.0.1-rc1', 'v4.0.1']
+describe('test parse semver string', () => {
+    it('No Version 3 Support', () => {
+        version3NoSupport.forEach((version) => {
+            const thisService = new ChainSemanticVersion(version)
+            expect(thisService.supportsLeap3Features()).not.toBeTruthy()
+            expect(thisService.supportsLeap4Features()).not.toBeTruthy()
+        })
+    })
+    it('Has Version 3 Support', () => {
+        version3WithSupport.forEach((version) => {
+            const thisService = new ChainSemanticVersion(version)
+            expect(thisService.supportsLeap3Features()).toBeTruthy()
+            expect(thisService.supportsLeap4Features()).not.toBeTruthy()
+        })
+    })
+    it('No Version 4 Support', () => {
+        version4NoSupport.forEach((version) => {
+            const thisService = new ChainSemanticVersion(version)
+            expect(thisService.supportsLeap3Features()).toBeTruthy()
+            expect(thisService.supportsLeap4Features()).not.toBeTruthy()
+        })
+    })
+    it('Has Version 4 Support', () => {
+        version4WithSupport.forEach((version) => {
+            const thisService = new ChainSemanticVersion(version)
+            expect(thisService.supportsLeap3Features()).toBeTruthy()
+            expect(thisService.supportsLeap4Features()).toBeTruthy()
+        })
+    })
+})

--- a/src/tests/eosjs-util.test.ts
+++ b/src/tests/eosjs-util.test.ts
@@ -17,8 +17,9 @@ const version3WithSupport = [
 ]
 const version4NoSupport = ['v4.0.0-rc1', 'v4.0.0-rc2', 'v4.0.0-rc3']
 const version4WithSupport = ['v4.0.0', 'v4.0.1-rc1', 'v4.0.1']
+
 describe('test parse semver string', () => {
-    it('No Version 3 Support', () => {
+    it('Lacks Version 3 Support', () => {
         version3NoSupport.forEach((version) => {
             const thisService = new ChainSemanticVersion(version)
             expect(thisService.supportsLeap3Features()).not.toBeTruthy()
@@ -32,7 +33,7 @@ describe('test parse semver string', () => {
             expect(thisService.supportsLeap4Features()).not.toBeTruthy()
         })
     })
-    it('No Version 4 Support', () => {
+    it('Lacks Version 4 Support', () => {
         version4NoSupport.forEach((version) => {
             const thisService = new ChainSemanticVersion(version)
             expect(thisService.supportsLeap3Features()).toBeTruthy()
@@ -45,5 +46,21 @@ describe('test parse semver string', () => {
             expect(thisService.supportsLeap3Features()).toBeTruthy()
             expect(thisService.supportsLeap4Features()).toBeTruthy()
         })
+    })
+    it('Check V4 No Patch with RC', () => {
+        // check version 4.0 no patch level will pass
+        const thisService = new ChainSemanticVersion('v4.0-rc12')
+        expect(thisService.supportsLeap3Features()).toBeTruthy()
+        expect(thisService.supportsLeap4Features()).not.toBeTruthy()
+    })
+    it('Check V4 No Patch', () => {
+        // check version 4.0 no patch level will pass
+        const thisServiceZero = new ChainSemanticVersion('v4.0')
+        expect(thisServiceZero.supportsLeap3Features()).toBeTruthy()
+        expect(thisServiceZero.supportsLeap4Features()).toBeTruthy()
+        // check version 4.1 no patch level will pass
+        const thisServiceOne = new ChainSemanticVersion('v4.1')
+        expect(thisServiceOne.supportsLeap3Features()).toBeTruthy()
+        expect(thisServiceOne.supportsLeap4Features()).toBeTruthy()
     })
 })

--- a/src/tests/node.js
+++ b/src/tests/node.js
@@ -17,7 +17,7 @@ const testRecipient = 'alicetestlio'
  */
 
 // TestNet.Local or TestNet.Jungle sets endpoint, blocksBehind, and expireSeconds
-const config = new TestConfig(TestNet.Jungle);
+const config = new TestConfig(TestNet.HomeBrew);
 const rpc = new JsonRpc(config.endpoint, { fetch });
 const signatureProvider = new JsSignatureProvider([privateKey]);
 const api = new Api({ rpc, signatureProvider, textDecoder: new TextDecoder(), textEncoder: new TextEncoder() });


### PR DESCRIPTION
## Change
Fixes #70 
The semver package is no longer shipped with nodeJS or shipped with browsers. This made using eosjs more difficult as developers would need to supply yet another package. The semver package was removed and replace by customer version parsing logic. See design considerations for additional info. 

### Listing of Commits
5d9b3bc rm semver package dep not available in nodejs

### Listing of Files Changed
package-lock.json
package.json
src/ChainSemanticVersion.ts
src/eosjs-api.ts
src/tests/eosjs-util.test.ts
src/tests/node.js

### API Changes
After this change ReadOnly calls throw an error if the server version is not 4.0.0 or better

### Design Considerations
The logic is a quirky. The 3.x features like send_transaction2 and transaction_status were officially supported in version 3.1.0. Pre-release candidates for 3.1.0 and versions 3.0.0 did not support the new endpoints.
In version 4 the logic is cleaner. Starting from version 4.0.0 send_read_only_transaction is supported
